### PR TITLE
Fixes for HTTP 1.0 not working when Content-Length not given

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ packages
 *.pidb
 TestResult.xml
 .DS_Store
+tests/HttpMachine.Tests/**

--- a/src/HttpMachine/HttpParser.cs
+++ b/src/HttpMachine/HttpParser.cs
@@ -50,7 +50,7 @@ namespace HttpMachine
         // int mark;
 
         
-#line 335 "rl/HttpParser.cs.rl"
+#line 343 "rl/HttpParser.cs.rl"
 
         
         
@@ -546,7 +546,7 @@ const int http_parser_en_body_identity_eof = 133;
 const int http_parser_en_dead = 130;
 
 
-#line 338 "rl/HttpParser.cs.rl"
+#line 346 "rl/HttpParser.cs.rl"
         
         public HttpParser(IHttpParserDelegate del)
         {
@@ -558,7 +558,7 @@ const int http_parser_en_dead = 130;
 	cs = http_parser_start;
 	}
 
-#line 344 "rl/HttpParser.cs.rl"
+#line 352 "rl/HttpParser.cs.rl"
         }
 
         public int Execute(ArraySegment<byte> buf)
@@ -592,7 +592,7 @@ _resume:
 	while ( _nacts-- > 0 ) {
 		switch ( _http_parser_actions[_acts++] ) {
 	case 31:
-#line 329 "rl/HttpParser.cs.rl"
+#line 337 "rl/HttpParser.cs.rl"
 	{
 			throw new Exception("Parser is dead; there shouldn't be more data. Client is bogus? fpc =" + p);
 		}
@@ -873,7 +873,9 @@ _match:
 				// if content length is given and non-zero, we should read that many bytes
 				// if content length is not given
 				//   if should keep alive, assume next request is coming and read it
-				//   else read body until EOF
+				//   else 
+				//		if chunked transfer read body until EOF
+				//   	else read next request
 
 				if (contentLength == 0)
 				{
@@ -898,16 +900,22 @@ _match:
 					}
 					else
 					{
-						//Console.WriteLine("Not keeping alive, will read until eof. Will hold, but currently fpc = " + fpc);
+						if (gotTransferEncodingChunked) {
+							//Console.WriteLine("Not keeping alive, will read until eof. Will hold, but currently fpc = " + fpc);
+							//fhold;
+							{cs = 133; if (true) goto _again;}
+						}
+		
+						del.OnMessageEnd(this);
 						//fhold;
-						{cs = 133; if (true) goto _again;}
+						{cs = 1; if (true) goto _again;}
 					}
 				}
 			}
         }
 	break;
 	case 29:
-#line 272 "rl/HttpParser.cs.rl"
+#line 280 "rl/HttpParser.cs.rl"
 	{
 			var toRead = Math.Min(pe - p, contentLength);
 			//Console.WriteLine("body_identity: reading " + toRead + " bytes from body.");
@@ -942,7 +950,7 @@ _match:
 		}
 	break;
 	case 30:
-#line 305 "rl/HttpParser.cs.rl"
+#line 313 "rl/HttpParser.cs.rl"
 	{
 			var toRead = pe - p;
 			//Console.WriteLine("body_identity_eof: reading " + toRead + " bytes from body.");
@@ -967,7 +975,7 @@ _match:
 			}
 		}
 	break;
-#line 971 "HttpParser.cs"
+#line 979 "HttpParser.cs"
 		default: break;
 		}
 	}
@@ -991,7 +999,7 @@ _again:
         }
 	break;
 	case 30:
-#line 305 "rl/HttpParser.cs.rl"
+#line 313 "rl/HttpParser.cs.rl"
 	{
 			var toRead = pe - p;
 			//Console.WriteLine("body_identity_eof: reading " + toRead + " bytes from body.");
@@ -1016,7 +1024,7 @@ _again:
 			}
 		}
 	break;
-#line 1020 "HttpParser.cs"
+#line 1028 "HttpParser.cs"
 		default: break;
 		}
 	}
@@ -1025,7 +1033,7 @@ _again:
 	_out: {}
 	}
 
-#line 359 "rl/HttpParser.cs.rl"
+#line 367 "rl/HttpParser.cs.rl"
             
             var result = p - buf.Offset;
 

--- a/src/HttpMachine/rl/HttpParser.cs.rl
+++ b/src/HttpMachine/rl/HttpParser.cs.rl
@@ -236,7 +236,9 @@ namespace HttpMachine
 				// if content length is given and non-zero, we should read that many bytes
 				// if content length is not given
 				//   if should keep alive, assume next request is coming and read it
-				//   else read body until EOF
+				//   else 
+				//		if chunked transfer read body until EOF
+				//   	else read next request
 
 				if (contentLength == 0)
 				{
@@ -261,9 +263,15 @@ namespace HttpMachine
 					}
 					else
 					{
-						//Console.WriteLine("Not keeping alive, will read until eof. Will hold, but currently fpc = " + fpc);
+						if (gotTransferEncodingChunked) {
+							//Console.WriteLine("Not keeping alive, will read until eof. Will hold, but currently fpc = " + fpc);
+							//fhold;
+							fgoto body_identity_eof;
+						}
+		
+						del.OnMessageEnd(this);
 						//fhold;
-						fgoto body_identity_eof;
+						fgoto main;
 					}
 				}
 			}

--- a/tests/HttpMachine.Tests/HttpMachineTests.cs
+++ b/tests/HttpMachine.Tests/HttpMachineTests.cs
@@ -469,10 +469,7 @@ namespace HttpMachine.Tests
 
                         //Console.WriteLine("Parsing buffer 3.");
                         Assert.AreEqual(buffer3Length, parser.Execute(new ArraySegment<byte>(buffer3, 0, buffer3Length)), "Error parsing buffer 3.");
-                        
-                        //Console.WriteLine("Parsing EOF");
-                        Assert.AreEqual(parser.Execute(default(ArraySegment<byte>)), 0, "Error parsing EOF chunk.");
-                        
+                                               
                         AssertRequest(requests.ToArray(), handler.Requests.ToArray(), parser);
                     }
             }

--- a/tests/HttpMachine.Tests/HttpMachineTests.cs
+++ b/tests/HttpMachine.Tests/HttpMachineTests.cs
@@ -286,6 +286,12 @@ namespace HttpMachine.Tests
             }
 
             [Test]
+            public void PostNoContentLength()
+            {
+                PipelineAndScan("1.0 post no content length");
+            }
+
+            [Test]
             public void Get()
             {
                 PipelineAndScan("1.0 get");

--- a/tests/HttpMachine.Tests/TestRequest.cs
+++ b/tests/HttpMachine.Tests/TestRequest.cs
@@ -336,7 +336,7 @@ namespace HttpMachine.Tests
                 Headers = new Dictionary<string,string>(StringComparer.InvariantCultureIgnoreCase) {
                     { "Foo", "Bar" }
                 },
-                Body = Encoding.UTF8.GetBytes("helloworldhello"),
+                Body = null,
                 ShouldKeepAlive = false
             },
             new TestRequest() {

--- a/tests/HttpMachine.Tests/TestRequest.cs
+++ b/tests/HttpMachine.Tests/TestRequest.cs
@@ -325,6 +325,23 @@ namespace HttpMachine.Tests
             },
             new TestRequest() {
                 Name = "1.0 post",
+                Raw = Encoding.ASCII.GetBytes("POST /foo HTTP/1.0\r\nContent-Length: 15\r\nFoo: Bar\r\n\r\nhelloworldhello"),
+                Method = "POST",
+                RequestUri = "/foo",
+                RequestPath = "/foo",
+                QueryString = null,
+                Fragment = null,
+                VersionMajor = 1,
+                VersionMinor = 0,
+                Headers = new Dictionary<string,string>(StringComparer.InvariantCultureIgnoreCase) {
+                    { "Content-Length", "15" },
+                    { "Foo", "Bar" }
+                },
+                Body = Encoding.UTF8.GetBytes("helloworldhello"),
+                ShouldKeepAlive = false
+            },
+            new TestRequest() {
+                Name = "1.0 post no content length",
                 Raw = Encoding.ASCII.GetBytes("POST /foo HTTP/1.0\r\nFoo: Bar\r\n\r\nhelloworldhello"),
                 Method = "POST",
                 RequestUri = "/foo",


### PR DESCRIPTION
Any HTTP 1.0 requests where hanging when Content-Length (CL) was not provided due to ShouldKeepAlive being false and parser waiting for end of request body.

Fixes include:
- Parser should not wait for a request body [that may not arrive] when CL is missing and Transfer-Encoding (TE) are missing.
- Fix test to follow standard more closely, a POST request without CL or TE should not be accepted (HTTP 400 or 411), so Body should be null as it was ignored.

NOTE: Failure to provide CL is a violation of HTTP/1.0 and failure to provide CL _and_ TE is a violation of HTTP/1.1 and should result in HTTP 400 or 411.
