### PR TITLE
Fix http 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ packages
 *.pidb
 TestResult.xml
 .DS_Store
+test-results/

--- a/src/HttpMachine/HttpParser.cs
+++ b/src/HttpMachine/HttpParser.cs
@@ -50,7 +50,7 @@ namespace HttpMachine
         // int mark;
 
         
-#line 335 "rl/HttpParser.cs.rl"
+#line 343 "rl/HttpParser.cs.rl"
 
         
         
@@ -546,7 +546,7 @@ const int http_parser_en_body_identity_eof = 133;
 const int http_parser_en_dead = 130;
 
 
-#line 338 "rl/HttpParser.cs.rl"
+#line 346 "rl/HttpParser.cs.rl"
         
         public HttpParser(IHttpParserDelegate del)
         {
@@ -558,7 +558,7 @@ const int http_parser_en_dead = 130;
 	cs = http_parser_start;
 	}
 
-#line 344 "rl/HttpParser.cs.rl"
+#line 352 "rl/HttpParser.cs.rl"
         }
 
         public int Execute(ArraySegment<byte> buf)
@@ -592,7 +592,7 @@ _resume:
 	while ( _nacts-- > 0 ) {
 		switch ( _http_parser_actions[_acts++] ) {
 	case 31:
-#line 329 "rl/HttpParser.cs.rl"
+#line 337 "rl/HttpParser.cs.rl"
 	{
 			throw new Exception("Parser is dead; there shouldn't be more data. Client is bogus? fpc =" + p);
 		}
@@ -873,7 +873,9 @@ _match:
 				// if content length is given and non-zero, we should read that many bytes
 				// if content length is not given
 				//   if should keep alive, assume next request is coming and read it
-				//   else read body until EOF
+				//   else 
+				//		if chunked transfer read body until EOF
+				//   	else read next request
 
 				if (contentLength == 0)
 				{
@@ -898,16 +900,22 @@ _match:
 					}
 					else
 					{
-						//Console.WriteLine("Not keeping alive, will read until eof. Will hold, but currently fpc = " + fpc);
+						if (gotTransferEncodingChunked) {
+							//Console.WriteLine("Not keeping alive, will read until eof. Will hold, but currently fpc = " + fpc);
+							//fhold;
+							{cs = 133; if (true) goto _again;}
+						}
+		
+						del.OnMessageEnd(this);
 						//fhold;
-						{cs = 133; if (true) goto _again;}
+						{cs = 1; if (true) goto _again;}
 					}
 				}
 			}
         }
 	break;
 	case 29:
-#line 272 "rl/HttpParser.cs.rl"
+#line 280 "rl/HttpParser.cs.rl"
 	{
 			var toRead = Math.Min(pe - p, contentLength);
 			//Console.WriteLine("body_identity: reading " + toRead + " bytes from body.");
@@ -942,7 +950,7 @@ _match:
 		}
 	break;
 	case 30:
-#line 305 "rl/HttpParser.cs.rl"
+#line 313 "rl/HttpParser.cs.rl"
 	{
 			var toRead = pe - p;
 			//Console.WriteLine("body_identity_eof: reading " + toRead + " bytes from body.");
@@ -967,7 +975,7 @@ _match:
 			}
 		}
 	break;
-#line 971 "HttpParser.cs"
+#line 979 "HttpParser.cs"
 		default: break;
 		}
 	}
@@ -991,7 +999,7 @@ _again:
         }
 	break;
 	case 30:
-#line 305 "rl/HttpParser.cs.rl"
+#line 313 "rl/HttpParser.cs.rl"
 	{
 			var toRead = pe - p;
 			//Console.WriteLine("body_identity_eof: reading " + toRead + " bytes from body.");
@@ -1016,7 +1024,7 @@ _again:
 			}
 		}
 	break;
-#line 1020 "HttpParser.cs"
+#line 1028 "HttpParser.cs"
 		default: break;
 		}
 	}
@@ -1025,7 +1033,7 @@ _again:
 	_out: {}
 	}
 
-#line 359 "rl/HttpParser.cs.rl"
+#line 367 "rl/HttpParser.cs.rl"
             
             var result = p - buf.Offset;
 

--- a/src/HttpMachine/rl/HttpParser.cs.rl
+++ b/src/HttpMachine/rl/HttpParser.cs.rl
@@ -236,7 +236,9 @@ namespace HttpMachine
 				// if content length is given and non-zero, we should read that many bytes
 				// if content length is not given
 				//   if should keep alive, assume next request is coming and read it
-				//   else read body until EOF
+				//   else 
+				//		if chunked transfer read body until EOF
+				//   	else read next request
 
 				if (contentLength == 0)
 				{
@@ -261,9 +263,15 @@ namespace HttpMachine
 					}
 					else
 					{
-						//Console.WriteLine("Not keeping alive, will read until eof. Will hold, but currently fpc = " + fpc);
+						if (gotTransferEncodingChunked) {
+							//Console.WriteLine("Not keeping alive, will read until eof. Will hold, but currently fpc = " + fpc);
+							//fhold;
+							fgoto body_identity_eof;
+						}
+		
+						del.OnMessageEnd(this);
 						//fhold;
-						fgoto body_identity_eof;
+						fgoto main;
 					}
 				}
 			}

--- a/tests/HttpMachine.Tests/HttpMachineTests.cs
+++ b/tests/HttpMachine.Tests/HttpMachineTests.cs
@@ -286,6 +286,12 @@ namespace HttpMachine.Tests
             }
 
             [Test]
+            public void PostNoContentLength()
+            {
+                PipelineAndScan("1.0 post no content length");
+            }
+
+			[Test]
             public void Get()
             {
                 PipelineAndScan("1.0 get");

--- a/tests/HttpMachine.Tests/HttpMachineTests.cs
+++ b/tests/HttpMachine.Tests/HttpMachineTests.cs
@@ -464,9 +464,6 @@ namespace HttpMachine.Tests
                         //Console.WriteLine("Parsing buffer 3.");
                         Assert.AreEqual(buffer3Length, parser.Execute(new ArraySegment<byte>(buffer3, 0, buffer3Length)), "Error parsing buffer 3.");
                         
-                        //Console.WriteLine("Parsing EOF");
-                        Assert.AreEqual(parser.Execute(default(ArraySegment<byte>)), 0, "Error parsing EOF chunk.");
-                        
                         AssertRequest(requests.ToArray(), handler.Requests.ToArray(), parser);
                     }
             }

--- a/tests/HttpMachine.Tests/TestRequest.cs
+++ b/tests/HttpMachine.Tests/TestRequest.cs
@@ -340,6 +340,22 @@ namespace HttpMachine.Tests
                 ShouldKeepAlive = false
             },
             new TestRequest() {
+                Name = "1.0 post no content length",
+                Raw = Encoding.ASCII.GetBytes("POST /foo HTTP/1.0\r\nFoo: Bar\r\n\r\nhelloworldhello"),
+                Method = "POST",
+                RequestUri = "/foo",
+                RequestPath = "/foo",
+                QueryString = null,
+                Fragment = null,
+                VersionMajor = 1,
+                VersionMinor = 0,
+                Headers = new Dictionary<string,string>(StringComparer.InvariantCultureIgnoreCase) {
+                    { "Foo", "Bar" }
+                },
+                Body = null,
+                ShouldKeepAlive = false
+            },
+			new TestRequest() {
                 Name = "1.0 post keep-alive with content length",
                 Raw = Encoding.ASCII.GetBytes("POST /foo HTTP/1.0\r\nContent-Length: 15\r\nFoo: Bar\r\nConnection: keep-alive\r\n\r\nhelloworldhello"),
                 Method = "POST",

--- a/tests/HttpMachine.Tests/TestRequest.cs
+++ b/tests/HttpMachine.Tests/TestRequest.cs
@@ -325,7 +325,7 @@ namespace HttpMachine.Tests
             },
             new TestRequest() {
                 Name = "1.0 post",
-                Raw = Encoding.ASCII.GetBytes("POST /foo HTTP/1.0\r\nFoo: Bar\r\n\r\nhelloworldhello"),
+                Raw = Encoding.ASCII.GetBytes("POST /foo HTTP/1.0\r\nContent-Length: 15\r\nFoo: Bar\r\n\r\nhelloworldhello"),
                 Method = "POST",
                 RequestUri = "/foo",
                 RequestPath = "/foo",
@@ -334,6 +334,7 @@ namespace HttpMachine.Tests
                 VersionMajor = 1,
                 VersionMinor = 0,
                 Headers = new Dictionary<string,string>(StringComparer.InvariantCultureIgnoreCase) {
+                    { "Content-Length", "15" },
                     { "Foo", "Bar" }
                 },
                 Body = Encoding.UTF8.GetBytes("helloworldhello"),


### PR DESCRIPTION
Once more, now with feeling! It was nagging me why HTTP 1.0 GET's were not failing in unit testing, and yet they failed with curl in a sample app.

Commits include:
- Fix test harness to _not_ provide EOF marker - real world clients will not disconnect/provide EOF until they have a response, so the parser needs to pass acceptable requests along, and only read to EOF if reasonably sure there's an entity body being sent. This change breaks a bunch of tests if not applied with the parser fixes below.
- Fix HTTP 1.0 POST to include Content-Length as per RFC
- Add HTTP 1.0 POST without Content-Length - this should not happen and if it does we should parse headers and then pass request along the stack so they can send HTTP 400/411 back. This test fails without parser fixes below.
- Fix parser to only read to EOF when an entity body is known to be present - Requests that fail to signal entity body presence should be replied to with error messages but should not hang parser until client drops connection.
- Minor update to gitignore to forget about test-results folders used by MonoDevelop [in current MD alpha at least]

Well known use cases triggering HTTP 1.0 usage include using nginx as a reverse proxy, possibly others.
